### PR TITLE
Fix .htaccess compatibility to resolve 500 internal server error

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,24 +1,20 @@
-# Security Headers for NoSpyLinks
-Header always set X-Frame-Options "DENY"
-Header always set X-Content-Type-Options "nosniff"
-Header always set Referrer-Policy "strict-origin-when-cross-origin"
-Header always set X-XSS-Protection "1; mode=block"
-Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+# Basic Security Headers for NoSpyLinks
+# Only include directives that work on most shared hosting
 
-# Content Security Policy
-Header always set Content-Security-Policy "default-src 'self'; script-src 'unsafe-inline' 'self'; style-src 'unsafe-inline' 'self'; img-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self' mailto:;"
-
-# Disable server signature
-ServerTokens Prod
-ServerSignature Off
+<IfModule mod_headers.c>
+    Header always set X-Frame-Options "DENY"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set Referrer-Policy "strict-origin-when-cross-origin"
+    Header always set X-XSS-Protection "1; mode=block"
+</IfModule>
 
 # Prevent access to sensitive files
 <FilesMatch "\.(htaccess|htpasswd|ini|log|sh|inc|bak)$">
-  Order Allow,Deny
-  Deny from all
+    Require all denied
 </FilesMatch>
 
-# Force HTTPS (uncomment when you have SSL certificate)
-# RewriteEngine On
-# RewriteCond %{HTTPS} off
-# RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+# Remove server signature if possible
+<IfModule mod_headers.c>
+    Header unset Server
+    Header unset X-Powered-By
+</IfModule>

--- a/.htaccess.minimal
+++ b/.htaccess.minimal
@@ -1,0 +1,7 @@
+# Minimal .htaccess for maximum compatibility
+# If this still causes 500 errors, delete this file entirely
+
+# Only basic file protection
+<Files ".htaccess">
+    Require all denied
+</Files>


### PR DESCRIPTION
- Simplified .htaccess directives for better shared hosting compatibility
- Wrapped headers in IfModule checks to prevent errors when mod_headers is not available
- Updated file access restrictions to use modern Apache 2.4 syntax
- Removed potentially problematic directives (ServerTokens, ServerSignature, CSP)
- Added minimal .htaccess.minimal as fallback option
- Security headers still provided via HTML meta tags